### PR TITLE
Add / handler fixing public self-check 404

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ func main() {
 
 	c := checker.NewChecker(checkerOpts...)
 	mux := http.NewServeMux()
+	mux.HandleFunc("/", healthHandler)
 	mux.HandleFunc("/health", healthHandler)
 	mux.HandleFunc("/check", c.HTTPHandler)
 


### PR DESCRIPTION
The public self-check hits the $PUBLIC_URL and logs a 404 error currently.
This patch adds the health (`OK`) handler to the `/` path to address this error.